### PR TITLE
Update RichTextEditor.js

### DIFF
--- a/MikeRobbinsSPEAKRichTextEditor/RichTextEditor.js
+++ b/MikeRobbinsSPEAKRichTextEditor/RichTextEditor.js
@@ -2,11 +2,11 @@
     require.config({
         paths: {
             tinyMCE: "/sitecore/shell/client/MikeRobbins/Components/RichTextEditor/tinymce/tinymce.min",
-            collection: "/sitecore/shell/client/Business Component Library/version 2/Layouts/Renderings/Mixins/Collection"
+            bclCollection: "/sitecore/shell/client/Business Component Library/version 2/Layouts/Renderings/Mixins/Collection"
         }
     });
 
-    Speak.component(["collection", "tinyMCE"], function (Collection, tinyMCE) {
+    Speak.component(["bclCollection", "tinyMCE"], function (Collection, tinyMCE) {
         return Speak.extend({}, Collection.prototype, {
             initialized: function () {
                 this.on("change:text", this.UpdateRichText);


### PR DESCRIPTION
Could not make it work in Sitecore 9.0.1. Seemed that the "collection" is already registered in the request as "bclCollection". Changing these two lines make it work in 9.0.1, I guess it breaks functionality in previous versions.